### PR TITLE
feat: initial implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:16-alpine
+RUN mkdir -p /home/node/app/node_modules
+WORKDIR /home/node/app
+COPY package*.json ./
+RUN chown -R node:node /home/node/app
+USER node
+RUN npm install
+COPY --chown=node:node . .
+CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Checkup
 
-A tool to check up on data stored in dotStorage, ensuring it is available and retrievable. It continuously takes random samples of 1,000 CIDs and creates a report exposed as prometheus metrics. Each new report overwrites the last.
+A tool to check up on data stored in dotStorage, ensuring it is available and retrievable. It continuously takes random samples of CIDs and exposes prometheus metrics on their availability.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,18 @@ Drop a `.env` file in the project root and populate:
 ```sh
 DATABASE_CONNECTION=<value>
 IPFS_CHECK_URL=<value>
+CLUSTER_API_URL=<value>
+CLUSTER_BASIC_AUTH_TOKEN=<value>
 PORT=3000 # optional, default shown
+PROM_NAMESPACE=checkup # optional, default shown
 ```
 
-Replace `DATABASE_CONNECTION` with the connection string for the database you want read from. Replace `IPFS_CHECK_URL` with an [ipfs-check](https://github.com/aschmahmann/ipfs-check) backend API URL.
+Replace the following values as specified:
+
+* `DATABASE_CONNECTION` with the connection string for the database you want read from.
+* `IPFS_CHECK_URL` with an [ipfs-check](https://github.com/aschmahmann/ipfs-check) backend API URL.
+* `CLUSTER_API_URL` with the base URL of the Cluster API.
+* `CLUSTER_BASIC_AUTH_TOKEN` with the base64 encoded basic auth token for the Cluster API.
 
 Start the checker:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Drop a `.env` file in the project root and populate:
 
 ```sh
 DATABASE_CONNECTION=<value>
-IPFS_CHECK_URL=<value>
+IPFS_CHECK_API_URL=<value>
 CLUSTER_API_URL=<value>
 CLUSTER_BASIC_AUTH_TOKEN=<value>
 PORT=3000 # optional, default shown

--- a/bin.js
+++ b/bin.js
@@ -7,7 +7,9 @@ dotenv.config()
 
 startCheckup({
   dbConnString: mustGetEnv('DATABASE_CONNECTION'),
-  ipfsCheckEndpoint: mustGetEnv('IPFS_CHECK_URL'),
+  ipfsCheckEndpoint: mustGetEnv('IPFS_CHECK_API_URL'),
+  clusterEndpoint: mustGetEnv('CLUSTER_API_URL'),
+  clusterBasicAuthToken: mustGetEnv('CLUSTER_BASIC_AUTH_TOKEN'),
   port: process.env.PORT
 })
 

--- a/check.js
+++ b/check.js
@@ -6,15 +6,18 @@ const log = debug('checkup:check')
  * @param {import('./ipfs-check-client').IpfsCheckClient} checker
  */
 export function checkCid (checker) {
-  return async function * checkCid (source) {
+  /**
+   * @param {ReturnType<ReturnType<import('./sample').getSample>>} source
+   */
+  return async function * (source) {
     // TODO: parallelise
-    for await (const candidate of source) {
-      log(`checking candidate ${candidate.sourceCid} @ ${candidate.peerId}`)
+    for await (const sample of source) {
+      log(`checking sample ${sample.cid} @ ${sample.peer}`)
       try {
-        const result = await checker.check(candidate.sourceCid, candidate.peerId)
-        yield { cid: candidate.sourceCid, peerId: candidate.peerId, result }
+        const result = await checker.check(sample.cid, `/p2p/${sample.peer}`)
+        yield { cid: sample.cid, peer: sample.peer, result }
       } catch (err) {
-        log(`failed to checkup on: ${candidate.sourceCid}`, err)
+        log(`failed to checkup on: ${sample.cid}`, err)
       }
     }
   }

--- a/check.js
+++ b/check.js
@@ -20,9 +20,7 @@ export function checkCid (checker) {
       log(`checking sample ${sample.cid} @ ${sample.peer}`)
       try {
         const result = await checker.check(sample.cid, `/p2p/${sample.peer}`)
-        /** @type {CheckedSample} */
-        const checkedSample = { ...sample, result }
-        yield checkedSample
+        yield /** @type {CheckedSample} */ ({ ...sample, result })
       } catch (err) {
         log(`failed to checkup on: ${sample.cid}`, err)
       }

--- a/check.js
+++ b/check.js
@@ -1,5 +1,11 @@
 import debug from 'debug'
 
+/**
+ * @typedef {import('./sample').Sample} Sample
+ * @typedef {import('./ipfs-check-client').IpfsCheckResult} IpfsCheckResult
+ * @typedef {{ result: IpfsCheckResult } & Sample} CheckedSample
+ */
+
 const log = debug('checkup:check')
 
 /**
@@ -7,15 +13,16 @@ const log = debug('checkup:check')
  */
 export function checkCid (checker) {
   /**
-   * @param {ReturnType<ReturnType<import('./sample').getSample>>} source
+   * @param {AsyncIterable<Sample>} source
    */
   return async function * (source) {
-    // TODO: parallelise
     for await (const sample of source) {
       log(`checking sample ${sample.cid} @ ${sample.peer}`)
       try {
         const result = await checker.check(sample.cid, `/p2p/${sample.peer}`)
-        yield { cid: sample.cid, peer: sample.peer, result }
+        /** @type {CheckedSample} */
+        const checkedSample = { ...sample, result }
+        yield checkedSample
       } catch (err) {
         log(`failed to checkup on: ${sample.cid}`, err)
       }

--- a/check.js
+++ b/check.js
@@ -2,8 +2,9 @@ import debug from 'debug'
 
 /**
  * @typedef {import('./sample').Sample} Sample
+ * @typedef {import('./peer').PeeredSample} PeeredSample
  * @typedef {import('./ipfs-check-client').IpfsCheckResult} IpfsCheckResult
- * @typedef {{ result: IpfsCheckResult } & Sample} CheckedSample
+ * @typedef {{ result: IpfsCheckResult } & PeeredSample} CheckedSample
  */
 
 const log = debug('checkup:check')
@@ -13,10 +14,16 @@ const log = debug('checkup:check')
  */
 export function checkCid (checker) {
   /**
-   * @param {AsyncIterable<Sample>} source
+   * @param {AsyncIterable<Sample|PeeredSample>} source
+   * @returns {AsyncIterable<Sample|CheckedSample>}
    */
   return async function * (source) {
     for await (const sample of source) {
+      // we can only check samples that have peers
+      if (!sample.peer) {
+        yield sample
+        continue
+      }
       log(`checking sample ${sample.cid} @ ${sample.peer}`)
       try {
         const result = await checker.check(sample.cid, `/p2p/${sample.peer}`)

--- a/check.js
+++ b/check.js
@@ -3,18 +3,18 @@ import debug from 'debug'
 const log = debug('checkup:check')
 
 /**
- * @param {IpfsCheckClient} checker
+ * @param {import('./ipfs-check-client').IpfsCheckClient} checker
  */
 export function checkCid (checker) {
   return async function * checkCid (source) {
     // TODO: parallelise
     for await (const candidate of source) {
-      log(`processing candidate ${candidate.sourceCid}`)
+      log(`checking candidate ${candidate.sourceCid} @ ${candidate.peerId}`)
       try {
-        const info = checker.check(candidate.sourceCid)
-        yield info
+        const result = await checker.check(candidate.sourceCid, candidate.peerId)
+        yield { cid: candidate.sourceCid, peerId: candidate.peerId, result }
       } catch (err) {
-        log(`failed to checkup on ${candidate.sourceCid}`, err)
+        log(`failed to checkup on: ${candidate.sourceCid}`, err)
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ export async function startCheckup ({
     } catch (err) {
       log('failed to close DB connection:', err)
     }
+    log('closing HTTP server...')
     server.close()
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import http from 'http'
 import { pipe } from 'it-pipe'
 import debug from 'debug'
 import pg from 'pg'
@@ -6,7 +7,7 @@ import fetch from '@web-std/fetch'
 import { IpfsCheckClient } from './ipfs-check-client.js'
 import { getSample } from './sample.js'
 import { checkCid } from './check.js'
-import { create } from './prom.js'
+import { createRegistry, recordMetrics } from './prom.js'
 
 globalThis.fetch = fetch
 
@@ -37,46 +38,28 @@ export async function startCheckup ({
   log('creating IPFS Check client...')
   const ipfsChecker = new IpfsCheckClient(ipfsCheckEndpoint)
 
-  log('creating Prometheus metrics server...')
-  const { metrics, server } = create(process.env.PROM_NAMESPACE)
-  server.listen(port)
+  log('creating Prometheus metrics registry...')
+  const { metrics, registry } = createRegistry(process.env.PROM_NAMESPACE)
+
+  log('creating HTTP server...')
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    if (url.pathname === '/metrics') {
+      res.write(await registry.metrics())
+    } else {
+      res.statusCode = 404
+      res.write('not found')
+    }
+    res.end()
+  })
+  server.listen(port, () => log(`server listening on: http://localhost:${port}`))
 
   try {
     await pipe(
       getSample(db, cluster),
       checkCid(ipfsChecker),
-      async source => {
-        for await (const data of source) {
-          metrics.samplesTotal.inc({ peer: data.peer })
-          if (data.result.ConnectionError) {
-            metrics.connectionErrorsTotal.inc({ peer: data.peer })
-          }
-          metrics.dhtProviderRecordsTotal.inc({
-            peer: data.peer,
-            found: data.result.CidInDHT
-          })
-          metrics.bitswapHaveDurationSeconds.inc({
-            peer: data.peer,
-            responded: data.result.DataAvailableOverBitswap.Responded,
-            found: data.result.DataAvailableOverBitswap.Found
-          }, data.result.DataAvailableOverBitswap.Duration / 1e+9)
-
-          if (
-            !data.result.ConnectionError &&
-            data.result.CidInDHT &&
-            data.result.DataAvailableOverBitswap.Responded &&
-            data.result.DataAvailableOverBitswap.Found
-          ) {
-            log(`✅ ${data.cid} @ ${data.peer}`)
-          } else {
-            log(`❌ ${data.cid} @ ${data.peer}`)
-            log(`\t${data.result.ConnectionError ? '🔴' : '🟢'} Connected`)
-            log(`\t${data.result.CidInDHT ? '🟢' : '🔴'} DHT provider record`)
-            log(`\t${data.result.DataAvailableOverBitswap.Responded ? '🟢' : '🔴'} Bitswap responded`)
-            log(`\t${data.result.DataAvailableOverBitswap.Found ? '🟢' : '🔴'} Bitswap found`)
-          }
-        }
-      }
+      recordMetrics(metrics),
+      logResult
     )
   } finally {
     try {
@@ -86,5 +69,24 @@ export async function startCheckup ({
       log('failed to close DB connection:', err)
     }
     server.close()
+  }
+}
+
+/**
+ * @param {AsyncIterable<import('./check.js').CheckedSample>} source
+ */
+async function logResult (source) {
+  for await (const { cid, peer, result } of source) {
+    const isOk = !result.ConnectionError &&
+      result.CidInDHT &&
+      result.DataAvailableOverBitswap.Responded &&
+      result.DataAvailableOverBitswap.Found
+    log(`${isOk ? '✅' : '❌'} ${cid} @ ${peer}`)
+    log(`\t${result.ConnectionError ? '🔴' : '🟢'} Connect success`)
+    log(`\t${result.CidInDHT ? '🟢' : '🔴'} DHT provider record found`)
+    if (!result.ConnectionError) {
+      log(`\t${result.DataAvailableOverBitswap.Responded ? '🟢' : '🔴'} Bitswap responded`)
+      log(`\t${result.DataAvailableOverBitswap.Found ? '🟢' : '🔴'} Bitswap found`)
+    }
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,60 +1,83 @@
 import { pipe } from 'it-pipe'
 import debug from 'debug'
 import pg from 'pg'
+import { Cluster } from '@nftstorage/ipfs-cluster'
+import fetch from '@web-std/fetch'
 import { IpfsCheckClient } from './ipfs-check-client.js'
 import { getSample } from './sample.js'
 import { checkCid } from './check.js'
 import { create } from './prom.js'
 
+globalThis.fetch = fetch
+
 const log = debug('checkup:index')
-const INTERVAL = 1000 * 60 * 5
 
 /**
  * @param {Object} config
  * @param {string} config.dbConnString dotStorage PostgreSQL connection string.
  * @param {string} config.ipfsCheckEndpoint IPFS Check backend API URL.
+ * @param {string} config.clusterEndpoint IPFS Cluster API URL.
+ * @param {string} config.clusterBasicAuthToken IPFS Cluster basic auth token.
  * @param {number} [config.port] Port to run the metrics server on.
  */
 export async function startCheckup ({
   dbConnString,
   ipfsCheckEndpoint,
+  clusterEndpoint,
+  clusterBasicAuthToken,
   port = 3000
 }) {
   log('connecting to PostgreSQL database...')
   const db = new pg.Client({ connectionString: dbConnString })
   await db.connect()
 
-  log('creating IPFS check client...')
+  log('creating IPFS Cluster client...')
+  const cluster = new Cluster(clusterEndpoint, { headers: { Authorization: `Basic ${clusterBasicAuthToken}` } })
+
+  log('creating IPFS Check client...')
   const ipfsChecker = new IpfsCheckClient(ipfsCheckEndpoint)
 
+  log('creating Prometheus metrics server...')
   const { metrics, server } = create(process.env.PROM_NAMESPACE)
   server.listen(port)
 
   try {
-    while (true) {
-      await pipe(
-        getSample(db),
-        checkCid(ipfsChecker),
-        async source => {
-          for await (const data of source) {
-            metrics.samplesTotal.inc({ peer: data.peerId })
-            if (data.result.ConnectionError) {
-              metrics.connectionErrorsTotal.inc({ peer: data.peerId })
-            }
-            metrics.dhtProviderRecordsTotal.inc({
-              peer: data.peerId,
-              found: data.result.CidInDHT
-            })
-            metrics.bitswapDurationSeconds.inc({
-              peer: data.peerId,
-              responded: data.result.DataAvailableOverBitswap.Responded,
-              found: data.result.DataAvailableOverBitswap.Found
-            }, data.result.DataAvailableOverBitswap.Duration / 1e+9)
+    await pipe(
+      getSample(db, cluster),
+      checkCid(ipfsChecker),
+      async source => {
+        for await (const data of source) {
+          metrics.samplesTotal.inc({ peer: data.peer })
+          if (data.result.ConnectionError) {
+            metrics.connectionErrorsTotal.inc({ peer: data.peer })
+          }
+          metrics.dhtProviderRecordsTotal.inc({
+            peer: data.peer,
+            found: data.result.CidInDHT
+          })
+          metrics.bitswapHaveDurationSeconds.inc({
+            peer: data.peer,
+            responded: data.result.DataAvailableOverBitswap.Responded,
+            found: data.result.DataAvailableOverBitswap.Found
+          }, data.result.DataAvailableOverBitswap.Duration / 1e+9)
+
+          if (
+            !data.result.ConnectionError &&
+            data.result.CidInDHT &&
+            data.result.DataAvailableOverBitswap.Responded &&
+            data.result.DataAvailableOverBitswap.Found
+          ) {
+            log(`✅ ${data.cid} @ ${data.peer}`)
+          } else {
+            log(`❌ ${data.cid} @ ${data.peer}`)
+            log(`\t${data.result.ConnectionError ? '🔴' : '🟢'} Connected`)
+            log(`\t${data.result.CidInDHT ? '🟢' : '🔴'} DHT provider record`)
+            log(`\t${data.result.DataAvailableOverBitswap.Responded ? '🟢' : '🔴'} Bitswap responded`)
+            log(`\t${data.result.DataAvailableOverBitswap.Found ? '🟢' : '🔴'} Bitswap found`)
           }
         }
-      )
-      await new Promise(resolve => setTimeout(resolve, INTERVAL))
-    }
+      }
+    )
   } finally {
     try {
       log('closing DB connection...')

--- a/ipfs-check-client.js
+++ b/ipfs-check-client.js
@@ -16,7 +16,7 @@ import fetch from '@web-std/fetch'
 
 export class IpfsCheckClient {
   /**
-   * @param {string} endpoint 
+   * @param {string} endpoint
    */
   constructor (endpoint) {
     this.endpoint = endpoint

--- a/ipfs-check-client.js
+++ b/ipfs-check-client.js
@@ -11,7 +11,7 @@ import fetch from '@web-std/fetch'
  *     Responded: boolean
  *     Error: string
  *   }
- * }} Output
+ * }} IpfsCheckResult
  */
 
 export class IpfsCheckClient {
@@ -22,6 +22,10 @@ export class IpfsCheckClient {
     this.endpoint = endpoint
   }
 
+  /**
+   * @param {string} cid
+   * @param {string} multiaddr
+   */
   async check (cid, multiaddr) {
     const url = new URL(this.endpoint)
     url.searchParams.set('cid', String(cid))
@@ -30,7 +34,7 @@ export class IpfsCheckClient {
     if (!res.ok) {
       throw new Error(`failed to check ${cid} @ ${multiaddr}: ${await res.text()}`)
     }
-    /** @type {Output} */
+    /** @type {IpfsCheckResult} */
     const out = await res.json()
     return out
   }

--- a/ipfs-check-client.js
+++ b/ipfs-check-client.js
@@ -1,0 +1,37 @@
+import fetch from '@web-std/fetch'
+
+/**
+ * @typedef {{
+ *   ConnectionError: string
+ *   PeerFoundInDHT: Record<string, number>
+ *   CidInDHT: boolean
+ *   DataAvailableOverBitswap: {
+ *     Duration: number
+ *     Found: boolean
+ *     Responded: boolean
+ *     Error: string
+ *   }
+ * }} Output
+ */
+
+export class IpfsCheckClient {
+  /**
+   * @param {string} endpoint 
+   */
+  constructor (endpoint) {
+    this.endpoint = endpoint
+  }
+
+  async check (cid, multiaddr) {
+    const url = new URL(this.endpoint)
+    url.searchParams.set('cid', String(cid))
+    url.searchParams.set('multiaddr', String(multiaddr))
+    const res = await fetch(url, { method: 'POST' })
+    if (!res.ok) {
+      throw new Error(`failed to check ${cid} @ ${multiaddr}: ${await res.text()}`)
+    }
+    /** @type {Output} */
+    const out = await res.json()
+    return out
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,86 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@nftstorage/ipfs-cluster": "^4.0.0",
+        "@web-std/fetch": "^4.0.0",
         "debug": "^4.3.3",
         "dotenv": "^16.0.0",
         "it-pipe": "^2.0.3",
-        "pg": "^8.7.3"
+        "pg": "^8.7.3",
+        "prom-client": "^14.0.1"
       }
+    },
+    "node_modules/@nftstorage/ipfs-cluster": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nftstorage/ipfs-cluster/-/ipfs-cluster-4.0.0.tgz",
+      "integrity": "sha512-PEt85HJdXpmQ8PULbC7iDdtf12KrM9tblR+o/2k+/0pvcpAdrplJeTQkUiEGRBiyeevjFXvyMs0f/eGpfxBBgA=="
+    },
+    "node_modules/@web-std/blob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.4.tgz",
+      "integrity": "sha512-+dibyiw+uHYK4dX5cJ7HA+gtDAaUUe6JsOryp2ZpAC7h4ICsh49E34JwHoEKPlPvP0llCrNzz45vvD+xX5QDBg==",
+      "dependencies": {
+        "@web-std/stream": "1.0.0",
+        "web-encoding": "1.1.5"
+      }
+    },
+    "node_modules/@web-std/fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-4.0.0.tgz",
+      "integrity": "sha512-RZUY1m7WoSsNGLfBeef3oAsmskU/IrlDSCMEakQZjD1csC91bdq3MJG7GiKijKJNg/PKRC45YxOo5yeSrAz5mA==",
+      "dependencies": {
+        "@web-std/blob": "^3.0.3",
+        "@web-std/form-data": "^3.0.2",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "data-uri-to-buffer": "^3.0.1",
+        "mrmime": "^1.0.0"
+      },
+      "engines": {
+        "node": "^10.17 || >=12.3"
+      }
+    },
+    "node_modules/@web-std/form-data": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-3.0.2.tgz",
+      "integrity": "sha512-rhc8IRw66sJ0FHcnC84kT3mTN6eACTuNftkt1XSl1Ef6WRKq4Pz65xixxqZymAZl1K3USpwhLci4SKNn4PYxWQ==",
+      "dependencies": {
+        "web-encoding": "1.1.5"
+      }
+    },
+    "node_modules/@web-std/stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.0.tgz",
+      "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
+      "dependencies": {
+        "web-streams-polyfill": "^3.1.1"
+      }
+    },
+    "node_modules/@web3-storage/multipart-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
+      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw=="
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "optional": true
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "node_modules/buffer-writer": {
       "version": "2.0.0",
@@ -21,6 +96,26 @@
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/debug": {
@@ -39,6 +134,17 @@
         }
       }
     },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
@@ -47,10 +153,344 @@
         "node": ">=12"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
       "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
+    },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/it-merge": {
       "version": "1.0.4",
@@ -88,10 +528,51 @@
       "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.4.tgz",
       "integrity": "sha512-0F3CqTIcIHwtnmIgqd03a7sw8BegAmE32N2w7anIGdALea4oAN4ltqPgDMZ7zn4XPLZifXEZlBXSzgg64L1Ebw=="
     },
+    "node_modules/mrmime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.0.tgz",
+      "integrity": "sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/packet-reader": {
       "version": "1.0.0",
@@ -207,12 +688,167 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/split2": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
       "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dependencies": {
+        "bintrees": "1.0.1"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dependencies": {
+        "util": "^0.12.3"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "0.9.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/xtend": {
@@ -225,10 +861,87 @@
     }
   },
   "dependencies": {
+    "@nftstorage/ipfs-cluster": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nftstorage/ipfs-cluster/-/ipfs-cluster-4.0.0.tgz",
+      "integrity": "sha512-PEt85HJdXpmQ8PULbC7iDdtf12KrM9tblR+o/2k+/0pvcpAdrplJeTQkUiEGRBiyeevjFXvyMs0f/eGpfxBBgA=="
+    },
+    "@web-std/blob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.4.tgz",
+      "integrity": "sha512-+dibyiw+uHYK4dX5cJ7HA+gtDAaUUe6JsOryp2ZpAC7h4ICsh49E34JwHoEKPlPvP0llCrNzz45vvD+xX5QDBg==",
+      "requires": {
+        "@web-std/stream": "1.0.0",
+        "web-encoding": "1.1.5"
+      }
+    },
+    "@web-std/fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-4.0.0.tgz",
+      "integrity": "sha512-RZUY1m7WoSsNGLfBeef3oAsmskU/IrlDSCMEakQZjD1csC91bdq3MJG7GiKijKJNg/PKRC45YxOo5yeSrAz5mA==",
+      "requires": {
+        "@web-std/blob": "^3.0.3",
+        "@web-std/form-data": "^3.0.2",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "data-uri-to-buffer": "^3.0.1",
+        "mrmime": "^1.0.0"
+      }
+    },
+    "@web-std/form-data": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-3.0.2.tgz",
+      "integrity": "sha512-rhc8IRw66sJ0FHcnC84kT3mTN6eACTuNftkt1XSl1Ef6WRKq4Pz65xixxqZymAZl1K3USpwhLci4SKNn4PYxWQ==",
+      "requires": {
+        "web-encoding": "1.1.5"
+      }
+    },
+    "@web-std/stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.0.tgz",
+      "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
+      "requires": {
+        "web-streams-polyfill": "^3.1.1"
+      }
+    },
+    "@web3-storage/multipart-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
+      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw=="
+    },
+    "@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "optional": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "debug": {
       "version": "4.3.3",
@@ -238,15 +951,240 @@
         "ms": "2.1.2"
       }
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "dotenv": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
       "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
     },
+    "es-abstract": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "fast-fifo": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
       "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
+    },
+    "is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "it-merge": {
       "version": "1.0.4",
@@ -286,10 +1224,36 @@
       "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.4.tgz",
       "integrity": "sha512-0F3CqTIcIHwtnmIgqd03a7sw8BegAmE32N2w7anIGdALea4oAN4ltqPgDMZ7zn4XPLZifXEZlBXSzgg64L1Ebw=="
     },
+    "mrmime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.0.tgz",
+      "integrity": "sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
     },
     "packet-reader": {
       "version": "1.0.0",
@@ -374,10 +1338,122 @@
         "xtend": "^4.0.0"
       }
     },
+    "prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "split2": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
       "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
+      }
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "util": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "requires": {
+        "@zxing/text-encoding": "0.9.0",
+        "util": "^0.12.3"
+      }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.7"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@web-std/fetch": "^4.0.0",
         "debug": "^4.3.3",
         "dotenv": "^16.0.0",
+        "it-batch": "^1.0.9",
         "it-pipe": "^2.0.3",
         "pg": "^8.7.3",
         "prom-client": "^14.0.1"
@@ -491,6 +492,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/it-batch": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.9.tgz",
+      "integrity": "sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA=="
     },
     "node_modules/it-merge": {
       "version": "1.0.4",
@@ -1185,6 +1191,11 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
+    },
+    "it-batch": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.9.tgz",
+      "integrity": "sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA=="
     },
     "it-merge": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,20 @@
   "author": "Alan Shaw",
   "license": "MIT",
   "dependencies": {
+    "@nftstorage/ipfs-cluster": "^4.0.0",
+    "@web-std/fetch": "^4.0.0",
     "debug": "^4.3.3",
     "dotenv": "^16.0.0",
     "it-pipe": "^2.0.3",
-    "pg": "^8.7.3"
-  }
+    "pg": "^8.7.3",
+    "prom-client": "^14.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nftstorage/checkup.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nftstorage/checkup/issues"
+  },
+  "homepage": "https://github.com/nftstorage/checkup#readme"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 DEBUG=backup:* node bin.js",
+    "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 DEBUG=checkup:* node bin.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@web-std/fetch": "^4.0.0",
     "debug": "^4.3.3",
     "dotenv": "^16.0.0",
+    "it-batch": "^1.0.9",
     "it-pipe": "^2.0.3",
     "pg": "^8.7.3",
     "prom-client": "^14.0.1"

--- a/peer.js
+++ b/peer.js
@@ -1,0 +1,55 @@
+import debug from 'debug'
+import batch from 'it-batch'
+import { randomInt } from './utils.js'
+
+/**
+ * @typedef {import('./sample').Sample} Sample
+ * @typedef {Sample & { peer: string }} PeeredSample
+ */
+
+const log = debug('checkup:peer')
+/**
+ * 8k max request length to cluster for statusAll, we hit this at around 126 CIDs
+ * http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers
+ */
+const MAX_CLUSTER_STATUS_CIDS = 120
+
+/**
+ * @param {import('@nftstorage/ipfs-cluster').Cluster} cluster
+ */
+export function selectPeer (cluster) {
+  /**
+   * @param {AsyncIterable<Sample>} source
+   * @returns {AsyncIterable<Sample|PeeredSample>}
+   */
+  return async function * (source) {
+    for await (const samples of batch(source, MAX_CLUSTER_STATUS_CIDS)) {
+      log(`retrieving cluster pin statuses for ${samples.length} CIDs`)
+      const statuses = await cluster.statusAll({ cids: samples.map(s => s.cid) })
+
+      for (const status of statuses) {
+        const pinInfos = Object.values(status.peerMap)
+        if (pinInfos.every(e => e.status === 'unpinned')) {
+          log(`⚠️ ${status.cid} is not pinned on ANY peer!`)
+          yield /** @type {Sample} */ ({ cid: status.cid })
+          continue
+        }
+
+        // pin information where:
+        // status != remote (pinned on another peer in the cluster)
+        // status != pin_queued (may not be available on this peer yet)
+        const eligiblePinInfos = pinInfos
+          .filter(i => i.status !== 'remote' && i.status !== 'pin_queued')
+
+        const pinInfo = eligiblePinInfos[randomInt(0, eligiblePinInfos.length)]
+        if (!pinInfo) {
+          log(`⚠️ ${status.cid} no eligible pin statuses: ${pinInfos.map(i => i.status)}`)
+          continue
+        }
+
+        log(`sample ready: ${status.cid} @ ${pinInfo.ipfsPeerId} (${pinInfo.status})`)
+        yield /** @type {PeeredSample} */ ({ cid: status.cid, peer: pinInfo.ipfsPeerId })
+      }
+    }
+  }
+}

--- a/prom.js
+++ b/prom.js
@@ -4,26 +4,29 @@ import * as Prom from 'prom-client'
 export function create (ns = 'checkup') {
   return {
     server: http.createServer(async (_, res) => {
-      res.set()
       res.write(await Prom.register.metrics())
       res.end()
     }),
     metrics: {
       samplesTotal: new Prom.Counter({
         name: `${ns}_samples_total`,
-        help: 'Number of random samples taken by peer ID.'
+        help: 'Number of random samples taken by peer ID.',
+        labelNames: ['peer']
       }),
       connectionErrorsTotal: new Prom.Counter({
         name: `${ns}_connection_errors_total`,
-        help: 'Number of samples taken where we were not able to connect to the target peer.'
+        help: 'Number of samples taken where we were not able to connect to the target peer.',
+        labelNames: ['peer']
       }),
       dhtProviderRecordsTotal: new Prom.Counter({
         name: `${ns}_dht_provider_records_total`,
-        help: 'Provider records found or not found by peer ID.'
+        help: 'Provider records found or not found by peer ID.',
+        labelNames: ['peer', 'found']
       }),
-      bitswapDurationSeconds: new Prom.Counter({
-        name: `${ns}_bitswap_duration_seconds`,
-        help: 'Time taken to check the peer has the sample CID over bitswap by peer ID.'
+      bitswapHaveDurationSeconds: new Prom.Counter({
+        name: `${ns}_bitswap_have_duration_seconds`,
+        help: 'Time taken to check the peer HAS the sample CID over bitswap by peer ID.',
+        labelNames: ['peer', 'responded', 'found']
       })
     }
   }

--- a/prom.js
+++ b/prom.js
@@ -53,19 +53,21 @@ export function recordMetrics (metrics) {
   return async function * (source) {
     for await (const sample of source) {
       const { peer, result } = sample
+      metrics.samplesTotal.inc({ peer: peer || 'unknown' })
 
-      metrics.samplesTotal.inc({ peer })
-      metrics.dhtProviderRecordsTotal.inc({ peer, found: result.CidInDHT })
+      if (peer) {
+        metrics.dhtProviderRecordsTotal.inc({ peer, found: result.CidInDHT })
 
-      if (result.ConnectionError) {
-        metrics.connectionErrorsTotal.inc({ peer })
-      } else {
-        const { Responded: responded, Found: found } = result.DataAvailableOverBitswap
-        metrics.bitswapRequestsTotal.inc({ peer, responded, found })
-        metrics.bitswapRequestDurationSeconds.inc(
-          { peer, responded, found },
-          result.DataAvailableOverBitswap.Duration / 1e+9
-        )
+        if (result.ConnectionError) {
+          metrics.connectionErrorsTotal.inc({ peer })
+        } else {
+          const { Responded: responded, Found: found } = result.DataAvailableOverBitswap
+          metrics.bitswapRequestsTotal.inc({ peer, responded, found })
+          metrics.bitswapRequestDurationSeconds.inc(
+            { peer, responded, found },
+            result.DataAvailableOverBitswap.Duration / 1e+9
+          )
+        }
       }
 
       yield sample

--- a/prom.js
+++ b/prom.js
@@ -1,17 +1,30 @@
 import http from 'http'
+import * as Prom from 'prom-client'
 
-export function createServer (getReport) {
-  return http.createServer((_, res) => {
-    const report = getReport()
-    if (report) {
-      res.write(formatReport(report))
-    } else {
-      res.statusCode = 404
+export function create (ns = 'checkup') {
+  return {
+    server: http.createServer(async (_, res) => {
+      res.set()
+      res.write(await Prom.register.metrics())
+      res.end()
+    }),
+    metrics: {
+      samplesTotal: new Prom.Counter({
+        name: `${ns}_samples_total`,
+        help: 'Number of random samples taken by peer ID.'
+      }),
+      connectionErrorsTotal: new Prom.Counter({
+        name: `${ns}_connection_errors_total`,
+        help: 'Number of samples taken where we were not able to connect to the target peer.'
+      }),
+      dhtProviderRecordsTotal: new Prom.Counter({
+        name: `${ns}_dht_provider_records_total`,
+        help: 'Provider records found or not found by peer ID.'
+      }),
+      bitswapDurationSeconds: new Prom.Counter({
+        name: `${ns}_bitswap_duration_seconds`,
+        help: 'Time taken to check the peer has the sample CID over bitswap by peer ID.'
+      })
     }
-    res.end()
-  })
-}
-
-function formatReport (report) {
-  return ''
+  }
 }

--- a/sample.js
+++ b/sample.js
@@ -1,5 +1,5 @@
 import debug from 'debug'
-import { randomInt, randomBigInt, sleep } from './utils.js'
+import { randomInt, randomBigInt } from './utils.js'
 
 /** @typedef {{ cid: string, peer: string }} Sample */
 
@@ -45,7 +45,6 @@ export function getSample (db, cluster) {
 
       if (!uploads.length) {
         log('⚠️ no uploads')
-        await sleep(5000)
         continue
       }
 
@@ -63,12 +62,11 @@ export function getSample (db, cluster) {
         // status != remote (pinned on another peer in the cluster)
         // status != pin_queued (may not be available on this peer yet)
         const eligiblePinInfos = pinInfos
-          .filter(info => info.status !== 'remote')
-          .filter(info => info.status !== 'pin_queued')
+          .filter(i => i.status !== 'remote' && i.status !== 'pin_queued')
 
         const pinInfo = eligiblePinInfos[randomInt(0, eligiblePinInfos.length)]
         if (!pinInfo) {
-          log(`⚠️ ${status.cid} no eligible pin statuses`)
+          log(`⚠️ ${status.cid} no eligible pin statuses: ${pinInfos.map(i => i.status)}`)
           continue
         }
 

--- a/sample.js
+++ b/sample.js
@@ -73,9 +73,7 @@ export function getSample (db, cluster) {
         }
 
         log(`sample ready: ${status.cid} @ ${pinInfo.ipfsPeerId} (${pinInfo.status})`)
-        /** @type {Sample} */
-        const sample = { cid: status.cid, peer: pinInfo.ipfsPeerId }
-        yield sample
+        yield /** @type {Sample} */ ({ cid: status.cid, peer: pinInfo.ipfsPeerId })
       }
     }
   }

--- a/sample.js
+++ b/sample.js
@@ -1,0 +1,53 @@
+/**
+ * 8k max request length to cluster for statusAll, we hit this at around 126 CIDs
+ * http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers
+ */
+const MAX_CLUSTER_STATUS_CIDS = 120
+const ESTIMATE_UPLOADS_SQL = 'SELECT reltuples::bigint AS estimate FROM pg_class WHERE relname = \'upload\''
+const FETCH_UPLOAD_AT_OFFSET_SQL = 'SELECT source_cid FROM upload OFFSET $1 LIMIT 1'
+
+/**
+ * The maximum is exclusive and the minimum is inclusive.
+ * @param {number} min
+ * @param {number} max
+ */
+function randomInt (min, max) {
+  min = Math.ceil(min)
+  max = Math.floor(max)
+  return Math.floor(Math.random() * (max - min) + min)
+}
+
+/**
+ * @param {import('pg').Client} db
+ */
+async function estimateUploads (db) {
+  const { rows } = await db.query(ESTIMATE_UPLOADS_SQL)
+  if (!rows.length) throw new Error('no rows returned estimating uploads')
+  return rows[0].estimate
+}
+
+/**
+ * @param {import('pg').Client} db
+ * @param {number} offset
+ * @returns {{ source_cid }|undefined}
+ */
+async function fetchUploadAtOffset (db, offset) {
+  const { rows } = await db.query(FETCH_UPLOAD_AT_OFFSET_SQL, [offset])
+  if (!rows.length) return
+  return rows[0]
+}
+
+/**
+ * @param {import('pg').Client} db
+ * @param {import('@nftstorage/ipfs-cluster').Cluster} cluster
+ */
+export function getSample (db, cluster) {
+  return async function * () {
+    while (true) {
+      const count = await estimateUploads(db)
+      const offsets = Array.from(Array(MAX_CLUSTER_STATUS_CIDS), () => randomInt(0, count))
+      const uploads = await Promise.all(offsets.map(i => fetchUploadAtOffset(db, i)))
+      const statuses = await cluster.statusAll({ cids: uploads.map(u => u.source_cid) })
+    }
+  }
+}

--- a/sample.js
+++ b/sample.js
@@ -1,6 +1,8 @@
 import debug from 'debug'
 import { randomInt, randomBigInt, sleep } from './utils.js'
 
+/** @typedef {{ cid: string, peer: string }} Sample */
+
 const log = debug('checkup:sample')
 /**
  * 8k max request length to cluster for statusAll, we hit this at around 126 CIDs
@@ -63,6 +65,7 @@ export function getSample (db, cluster) {
         const eligiblePinInfos = pinInfos
           .filter(info => info.status !== 'remote')
           .filter(info => info.status !== 'pin_queued')
+
         const pinInfo = eligiblePinInfos[randomInt(0, eligiblePinInfos.length)]
         if (!pinInfo) {
           log(`⚠️ ${status.cid} no eligible pin statuses`)
@@ -70,10 +73,10 @@ export function getSample (db, cluster) {
         }
 
         log(`sample ready: ${status.cid} @ ${pinInfo.ipfsPeerId} (${pinInfo.status})`)
-        yield { cid: status.cid, peer: pinInfo.ipfsPeerId }
+        /** @type {Sample} */
+        const sample = { cid: status.cid, peer: pinInfo.ipfsPeerId }
+        yield sample
       }
-
-      await sleep(5000)
     }
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -22,10 +22,3 @@ export function randomBigInt (min, max) {
   }
   return min + (rand % range)
 }
-
-/**
- * @param {number} ms
- */
-export function sleep (ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,31 @@
+/**
+ * The maximum is exclusive and the minimum is inclusive.
+ * @param {number} min
+ * @param {number} max
+ */
+export function randomInt (min, max) {
+  return Math.floor(Math.random() * (max - min) + min)
+}
+
+/**
+ * The maximum is exclusive and the minimum is inclusive.
+ * @param {bigint} min
+ * @param {bigint} max
+ */
+export function randomBigInt (min, max) {
+  const range = max - min
+  let rand = 0n
+  let digits = range.toString().length / 9 + 2 | 0
+  while (digits--) {
+    rand *= 1000000000n
+    rand += BigInt(Math.random() * 1000000000 | 0)
+  }
+  return min + (rand % range)
+}
+
+/**
+ * @param {number} ms
+ */
+export function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
This PR adds an initial implementation that we can run easily in DO apps. We'll probably need to run our own IPFS Check server at some point...

1. Fetches 120 random _uploads_ from the database
2. Asks Cluster for the current pin status for those CIDs
3. Picks a random peer (from the 3 it'll be pinned on)
4. Asks [IPFS check](https://ipfs-check.on.fleek.co/) about connectability, existence of a dht provider record for the root CID and availability over bitswap
5. Records metrics and exposes a HTTP endpoint that serves them in prometheus exposition format
6. Starts again...

We have so many uploads that it would take forever to check every single one and we may never finish (due to the rate they're coming in). Instead of doing a full round trip to create a report that'll be out of date as soon as it's generated, the idea here is to continuously sample random CIDs to give us up-to-date metrics that we can graph.

Sample log output:

<img width="1112" alt="Screenshot 2022-03-02 at 17 09 02" src="https://user-images.githubusercontent.com/152863/156412055-ad5a3640-4aec-40fd-a79f-76d09150fc9e.png">

Sample prom metrics response:

<img width="1335" alt="Screenshot 2022-03-02 at 14 30 57" src="https://user-images.githubusercontent.com/152863/156412170-3f5e766f-6926-4aed-be45-07222c373e19.png">


