### PR TITLE
Log non-connection related errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,9 @@ async function logResult (source) {
       if (!result.ConnectionError) {
         log(`\t${result.DataAvailableOverBitswap.Responded ? '🟢' : '🔴'} Bitswap responded`)
         log(`\t${result.DataAvailableOverBitswap.Found ? '🟢' : '🔴'} Bitswap found`)
+        if (!result.DataAvailableOverBitswap.Responded || !result.DataAvailableOverBitswap.Found) {
+          log(`\tCID ${cid}, Peer ${peer}, Bitswap Error: ${result.DataAvailableOverBitswap.Error}`)
+        }
       }
     }
   }


### PR DESCRIPTION
Log the error in order to diagnose why a `cid` was not found or why bitswap failed to respond